### PR TITLE
Add cleanup sprint with 7 tech debt tickets (PF-027–PF-033)

### DIFF
--- a/.kanban/BOARD.md
+++ b/.kanban/BOARD.md
@@ -1,6 +1,6 @@
 # Personal Finance — Kanban Board
 
-> **Current Sprint:** Pre-Sprint (Ramp-Up Week 0)
+> **Current Sprint:** Cleanup → then Ramp-Up (Week 0)
 > **Last Updated:** 2026-03-01
 > **WIP Limit:** 2 tasks in progress
 
@@ -32,6 +32,13 @@
 
 | ID | Task | Sprint | Labels |
 |----|------|--------|--------|
+| [PF-027](tasks/PF-027.md) | Delete scaffold leftovers and dead code | cleanup | `infra` |
+| [PF-028](tasks/PF-028.md) | Fix exception detail leaking to API clients | cleanup | `infra` |
+| [PF-029](tasks/PF-029.md) | Fix N+1 query in CategorizeAsync | cleanup | `infra` |
+| [PF-030](tasks/PF-030.md) | Move DTOs to correct project | cleanup | `infra` |
+| [PF-031](tasks/PF-031.md) | Extract dashboard aggregation from controller | cleanup | `infra` |
+| [PF-032](tasks/PF-032.md) | Update PROJECT_CONTEXT.md to match codebase | cleanup | `docs` |
+| [PF-033](tasks/PF-033.md) | Add Current Phase section to CLAUDE.md | cleanup | `docs` |
 | [PF-009](tasks/PF-009.md) | Hello LLM — first Anthropic API call | ramp-up | `learning` `ai` |
 | [PF-010](tasks/PF-010.md) | Structured output — text → JSON via LLM | ramp-up | `learning` `ai` |
 | [PF-011](tasks/PF-011.md) | FastAPI AI microservice scaffold | ramp-up | `learning` `ai` `infra` |
@@ -73,11 +80,12 @@
 
 ```
 Setup:    ████████████████████ 100% (8/8)
+Cleanup:  ░░░░░░░░░░░░░░░░░░░░   0% (0/7)
 Ramp-Up:  ░░░░░░░░░░░░░░░░░░░░   0% (0/6)
 Sprint 1: ░░░░░░░░░░░░░░░░░░░░   0% (0/3)
 Sprint 2: ░░░░░░░░░░░░░░░░░░░░   0% (0/3)
 Sprint 3: ░░░░░░░░░░░░░░░░░░░░   0% (0/3)
 Sprint 4: ░░░░░░░░░░░░░░░░░░░░   0% (0/3)
 ──────────────────────────────────
-Overall:  ████░░░░░░░░░░░░░░░░  31% (8/26)
+Overall:  ██░░░░░░░░░░░░░░░░░░  24% (8/33)
 ```

--- a/.kanban/board.html
+++ b/.kanban/board.html
@@ -285,7 +285,7 @@
 <header>
   <h1>Personal Finance <span>— Kanban Board</span></h1>
   <div class="meta">
-    <div>Sprint: <strong>Pre-Sprint (Ramp-Up)</strong></div>
+    <div>Sprint: <strong>Cleanup → Ramp-Up</strong></div>
     <div>Updated: <strong>2026-03-01</strong></div>
     <div>WIP Limit: <strong>2</strong></div>
   </div>
@@ -296,6 +296,7 @@
 <div class="filter-bar">
   <button class="filter-btn active" onclick="filterSprint('all')">All</button>
   <button class="filter-btn" onclick="filterSprint('setup')">Setup</button>
+  <button class="filter-btn" onclick="filterSprint('cleanup')">Cleanup</button>
   <button class="filter-btn" onclick="filterSprint('ramp-up')">Ramp-Up</button>
   <button class="filter-btn" onclick="filterSprint('S1')">Sprint 1</button>
   <button class="filter-btn" onclick="filterSprint('S2')">Sprint 2</button>
@@ -324,7 +325,16 @@ const tasks = [
   { id: "PF-007", title: "Category rules feature (CRUD)", status: "done", sprint: "setup", labels: ["feature"], completed: "2026-02" },
   { id: "PF-008", title: "Cash flow dashboard with charts", status: "done", sprint: "setup", labels: ["feature"], completed: "2026-02" },
 
-  // ── READY ──
+  // ── READY (Cleanup) ──
+  { id: "PF-027", title: "Delete scaffold leftovers and dead code", status: "ready", sprint: "cleanup", labels: ["infra"] },
+  { id: "PF-028", title: "Fix exception detail leaking to API clients", status: "ready", sprint: "cleanup", labels: ["infra"] },
+  { id: "PF-029", title: "Fix N+1 query in CategorizeAsync", status: "ready", sprint: "cleanup", labels: ["infra"] },
+  { id: "PF-030", title: "Move DTOs to correct project", status: "ready", sprint: "cleanup", labels: ["infra"] },
+  { id: "PF-031", title: "Extract dashboard aggregation from controller", status: "ready", sprint: "cleanup", labels: ["infra"] },
+  { id: "PF-032", title: "Update PROJECT_CONTEXT.md to match codebase", status: "ready", sprint: "cleanup", labels: ["docs"] },
+  { id: "PF-033", title: "Add Current Phase section to CLAUDE.md", status: "ready", sprint: "cleanup", labels: ["docs"] },
+
+  // ── READY (Ramp-Up) ──
   { id: "PF-009", title: "Hello LLM \u2014 first Anthropic API call", status: "ready", sprint: "ramp-up", labels: ["learning", "ai"] },
   { id: "PF-010", title: "Structured output \u2014 text \u2192 JSON via LLM", status: "ready", sprint: "ramp-up", labels: ["learning", "ai"] },
   { id: "PF-011", title: "FastAPI AI microservice scaffold", status: "ready", sprint: "ramp-up", labels: ["learning", "ai", "infra"] },
@@ -417,6 +427,7 @@ function renderBoard() {
 function renderProgress() {
   const sprintConfigs = [
     { key: "setup", name: "Setup", color: "#8b949e" },
+    { key: "cleanup", name: "Cleanup", color: "#f0883e" },
     { key: "ramp-up", name: "Ramp-Up", color: "#3fb950" },
     { key: "S1", name: "Sprint 1", color: "#58a6ff" },
     { key: "S2", name: "Sprint 2", color: "#bc8cff" },

--- a/.kanban/tasks/PF-027.md
+++ b/.kanban/tasks/PF-027.md
@@ -1,0 +1,42 @@
+# PF-027: Delete scaffold leftovers and dead code
+
+| Field       | Value                  |
+|-------------|------------------------|
+| **ID**      | PF-027                 |
+| **Status**  | Ready                  |
+| **Sprint**  | cleanup                |
+| **Labels**  | `infra`                |
+| **Created** | 2026-03-01             |
+| **Updated** | 2026-03-01             |
+
+---
+
+## Objective
+
+Remove template scaffold files and a third-party CDN script that add confusion and pose a security risk. Quick win cleanup before AI ramp-up.
+
+## Acceptance Criteria
+
+- [ ] `api/src/PersonalFinance.Api/WeatherForecast.cs` deleted
+- [ ] `api/src/PersonalFinance.Api/Controllers/WeatherForecastController.cs` deleted (verify exact path)
+- [ ] `api/tests/PersonalFinance.Tests/UnitTest1.cs` deleted
+- [ ] `index.html` — `<script src="https://cdn.gpteng.co/gptengineer.js">` line removed
+- [ ] `dotnet build PersonalFinance.slnx` succeeds
+- [ ] `dotnet test` passes (11 tests)
+- [ ] `npm run build` succeeds
+
+## Technical Notes
+
+**WeatherForecast files:** .NET project template leftovers. Not referenced by any other code.
+
+**UnitTest1.cs:** Empty test file with no `[Fact]` or `[Theory]` attributes. Violates TEST-04 governance rule.
+
+**CDN script:** `index.html` loads an unpinned third-party script from `cdn.gpteng.co`. This is a security risk (SEC-03) — no external scripts should be loaded outside the Vite bundle.
+
+## Dependencies
+
+- None (standalone cleanup)
+
+## Notes
+
+_Estimated: 5 minutes. No risk of breaking changes._

--- a/.kanban/tasks/PF-028.md
+++ b/.kanban/tasks/PF-028.md
@@ -1,0 +1,54 @@
+# PF-028: Fix exception detail leaking to API clients
+
+| Field       | Value                  |
+|-------------|------------------------|
+| **ID**      | PF-028                 |
+| **Status**  | Ready                  |
+| **Sprint**  | cleanup                |
+| **Labels**  | `infra`                |
+| **Created** | 2026-03-01             |
+| **Updated** | 2026-03-01             |
+
+---
+
+## Objective
+
+Stop returning internal exception messages (`ex.Message`) in HTTP 500 responses. Replace with generic error messages to prevent information leakage. Addresses ERR-01 governance rule.
+
+## Acceptance Criteria
+
+- [ ] `TransactionsController.UploadPreview` catch block returns generic message instead of `ex.Message`
+- [ ] `TransactionsController.GetDashboardData` catch block returns generic message instead of `ex.Message`
+- [ ] No `ex.Message` or `ex.StackTrace` in any HTTP response body across all controllers
+- [ ] `dotnet build` succeeds
+- [ ] API still returns 500 status code for unexpected errors (just with safe message)
+
+## Technical Notes
+
+**Current violations in `api/src/PersonalFinance.Api/Controllers/TransactionsController.cs`:**
+
+Line 98:
+```csharp
+return StatusCode(500, $"Failed to parse file: {ex.Message}");
+```
+
+Line 277:
+```csharp
+return StatusCode(500, $"Failed to retrieve dashboard data: {ex.Message}");
+```
+
+**Fix:** Replace with generic messages:
+```csharp
+return StatusCode(500, new { Message = "File processing failed." });
+return StatusCode(500, new { Message = "Failed to retrieve dashboard data." });
+```
+
+**Future improvement:** Add `ILogger<TransactionsController>` injection and log the full exception before returning (tracked separately in ERR-02).
+
+## Dependencies
+
+- None
+
+## Notes
+
+_Estimated: 10 minutes. Security fix — prevents leaking internal server details to clients._

--- a/.kanban/tasks/PF-029.md
+++ b/.kanban/tasks/PF-029.md
@@ -1,0 +1,74 @@
+# PF-029: Fix N+1 query in CategorizeAsync
+
+| Field       | Value                  |
+|-------------|------------------------|
+| **ID**      | PF-029                 |
+| **Status**  | Ready                  |
+| **Sprint**  | cleanup                |
+| **Labels**  | `infra`                |
+| **Created** | 2026-03-01             |
+| **Updated** | 2026-03-01             |
+
+---
+
+## Objective
+
+Fix the N+1 query pattern in `CategoryRuleService.CategorizeAsync()` which queries the database once per transaction row. A 500-row file import generates 500 DB queries. Addresses PERF-01 governance rule.
+
+## Acceptance Criteria
+
+- [ ] New `CategorizeBatchAsync(List<TransactionDto> transactions)` method added to `ICategoryRuleService` and `CategoryRuleService`
+- [ ] Batch method loads all category rules once, categorizes all transactions in-memory
+- [ ] Callers in parsers/import service updated to use batch method
+- [ ] Existing `CategorizeAsync(string, string)` still works for single-item use cases
+- [ ] Existing tests pass
+- [ ] New test: `CategorizeBatchAsync_WithMultipleTransactions_QueriesDbOnce`
+- [ ] `dotnet build` succeeds
+
+## Technical Notes
+
+**Current code** (`api/src/PersonalFinance.Application/Services/CategoryRuleService.cs`):
+```csharp
+public async Task<string> CategorizeAsync(string description, string type)
+{
+    var rules = await _dbContext.CategoryRules  // DB query per call!
+        .Where(r => r.Type.ToLower() == type.ToLower())
+        .OrderByDescending(r => r.KeywordLength)
+        .ToListAsync();
+    // ...
+}
+```
+
+**Fix — add batch method:**
+```csharp
+public async Task<List<TransactionDto>> CategorizeBatchAsync(List<TransactionDto> transactions)
+{
+    var rules = await _dbContext.CategoryRules
+        .OrderByDescending(r => r.KeywordLength)
+        .ToListAsync();  // Single DB query
+
+    foreach (var tx in transactions)
+    {
+        var matchingRules = rules.Where(r => r.Type.Equals(tx.Type, StringComparison.OrdinalIgnoreCase));
+        foreach (var rule in matchingRules)
+        {
+            if (tx.Description.Contains(rule.Keyword, StringComparison.OrdinalIgnoreCase))
+            {
+                tx.Category = rule.Category;
+                break;
+            }
+        }
+    }
+    return transactions;
+}
+```
+
+**Callers to update:** Check `StatementImportService` and individual parsers for `CategorizeAsync` calls inside loops.
+
+## Dependencies
+
+- None
+
+## Notes
+
+_Estimated: 20 minutes. Performance fix — reduces DB queries from O(n) to O(1) per file import._

--- a/.kanban/tasks/PF-030.md
+++ b/.kanban/tasks/PF-030.md
@@ -1,0 +1,48 @@
+# PF-030: Move DTOs to correct project (fix namespace/location mismatch)
+
+| Field       | Value                  |
+|-------------|------------------------|
+| **ID**      | PF-030                 |
+| **Status**  | Ready                  |
+| **Sprint**  | cleanup                |
+| **Labels**  | `infra`                |
+| **Created** | 2026-03-01             |
+| **Updated** | 2026-03-01             |
+
+---
+
+## Objective
+
+Fix the namespace/physical-location mismatch where DTO files live in `Infrastructure/Dtos/` but declare `namespace PersonalFinance.Application.Dtos`. Move them to the Application project where they belong. Addresses ARCH-03 governance rule.
+
+## Acceptance Criteria
+
+- [ ] `TransactionDto.cs` moved from `Infrastructure/Dtos/` to `Application/Dtos/`
+- [ ] `CategoryRuleDto.cs` moved from `Infrastructure/Dtos/` to `Application/Dtos/`
+- [ ] Empty `<Folder Include="Dtos\" />` removed from `Application.csproj`
+- [ ] All `using` statements across the solution still resolve
+- [ ] `dotnet build PersonalFinance.slnx` succeeds
+- [ ] `dotnet test` passes
+
+## Technical Notes
+
+**Current state:**
+- `api/src/PersonalFinance.Infrastructure/Dtos/TransactionDto.cs` — `namespace PersonalFinance.Application.Dtos`
+- `api/src/PersonalFinance.Infrastructure/Dtos/CategoryRuleDto.cs` — `namespace PersonalFinance.Application.Dtos`
+- `api/src/PersonalFinance.Application/PersonalFinance.Application.csproj` — has `<Folder Include="Dtos\" />` placeholder
+
+**After fix:**
+- Files physically in `Application/Dtos/`
+- Namespace stays `PersonalFinance.Application.Dtos` (unchanged)
+- No `using` changes needed since namespace is already correct
+- Remove the empty folder include from .csproj
+
+**Risk:** Low. Namespace doesn't change, only file location. All existing references continue to compile.
+
+## Dependencies
+
+- None
+
+## Notes
+
+_Estimated: 15 minutes. Architecture hygiene — physical file location should match declared namespace._

--- a/.kanban/tasks/PF-031.md
+++ b/.kanban/tasks/PF-031.md
@@ -1,0 +1,61 @@
+# PF-031: Extract dashboard aggregation from controller to service
+
+| Field       | Value                  |
+|-------------|------------------------|
+| **ID**      | PF-031                 |
+| **Status**  | Ready                  |
+| **Sprint**  | cleanup                |
+| **Labels**  | `infra`                |
+| **Created** | 2026-03-01             |
+| **Updated** | 2026-03-01             |
+
+---
+
+## Objective
+
+Move ~100 lines of inline aggregation logic from `TransactionsController.GetDashboardData()` into a dedicated service. Also extract inline category rule creation logic from `SubmitTransactions()`. Controllers should be thin: validate, delegate, return. Addresses ARCH-04 governance rule.
+
+## Acceptance Criteria
+
+- [ ] `IDashboardService` interface created in `Application/Interfaces/`
+- [ ] `DashboardService` implementation in `Application/Services/`
+- [ ] `GetDashboardDataAsync(wallet, year, month)` method contains all aggregation logic
+- [ ] Category rule creation logic extracted from `SubmitTransactions` into import service
+- [ ] Controller action bodies are < 15 lines each
+- [ ] DI registration added in `Program.cs`
+- [ ] API responses identical to current behavior (no breaking changes)
+- [ ] `dotnet build` succeeds
+- [ ] `dotnet test` passes
+
+## Technical Notes
+
+**Current:** `TransactionsController.GetDashboardData()` (lines 178-279) contains:
+- Year/month filtering
+- Income/expense aggregation
+- Month-over-month percentage change calculations
+- Top categories grouping
+- 6-month cash flow computation
+
+**Current:** `TransactionsController.SubmitTransactions()` (lines 102-146) contains:
+- Loop over DTOs checking category existence
+- Inline category rule creation via `_categoryRuleService.AddAsync()`
+- DTO-to-DTO mapping (no-op mapping that can be removed)
+
+**After refactoring:**
+```csharp
+// Controller becomes:
+[HttpGet("aggregated")]
+public async Task<IActionResult> GetDashboardData(string? wallet, int? year, int? month)
+{
+    var data = await _dashboardService.GetDashboardDataAsync(wallet, year, month);
+    return Ok(data);
+}
+```
+
+## Dependencies
+
+- None
+
+## Notes
+
+_Estimated: 30 minutes. Largest cleanup ticket. Improves testability — dashboard logic becomes independently unit-testable._

--- a/.kanban/tasks/PF-032.md
+++ b/.kanban/tasks/PF-032.md
@@ -1,0 +1,41 @@
+# PF-032: Update PROJECT_CONTEXT.md to match actual codebase
+
+| Field       | Value                  |
+|-------------|------------------------|
+| **ID**      | PF-032                 |
+| **Status**  | Ready                  |
+| **Sprint**  | cleanup                |
+| **Labels**  | `docs`                 |
+| **Created** | 2026-03-01             |
+| **Updated** | 2026-03-01             |
+
+---
+
+## Objective
+
+Fix documented values in PROJECT_CONTEXT.md that drift from the actual codebase: .NET version, testing framework, ID types, and service boundary labels.
+
+## Acceptance Criteria
+
+- [ ] Section 11: ".NET 8 (LTS), C# 12" changed to ".NET 9, C# 13"
+- [ ] Section 11: "NSubstitute" changed to "Moq"
+- [ ] Section 8: `Id: Guid` changed to `Id: int` for Transaction schema
+- [ ] Section 8: `BankProfileId: Guid` changed to `BankProfileId: int`
+- [ ] Section 8: Note added that schema evolves incrementally (current entity has 11 fields, full schema is the target)
+- [ ] Section 6: ".NET 8 Web API" changed to ".NET 9 Web API" in service boundaries diagram
+
+## Technical Notes
+
+**File:** `docs/PROJECT_CONTEXT.md`
+
+These are straightforward text replacements. The document is a planning artifact — updating it to reflect implementation decisions prevents confusion in future sessions.
+
+**Why `int` not `Guid`:** The Transaction entity uses `int` PKs, EF Core auto-increments them, 5 migrations already exist. Changing to Guid would require a migration rewrite with data loss. `int` is fine for a single-user personal finance app.
+
+## Dependencies
+
+- None
+
+## Notes
+
+_Estimated: 10 minutes. Documentation accuracy fix._

--- a/.kanban/tasks/PF-033.md
+++ b/.kanban/tasks/PF-033.md
@@ -1,0 +1,78 @@
+# PF-033: Add Current Phase section to CLAUDE.md
+
+| Field       | Value                  |
+|-------------|------------------------|
+| **ID**      | PF-033                 |
+| **Status**  | Ready                  |
+| **Sprint**  | cleanup                |
+| **Labels**  | `docs`                 |
+| **Created** | 2026-03-01             |
+| **Updated** | 2026-03-01             |
+
+---
+
+## Objective
+
+Add a `## Current Phase` section to CLAUDE.md so future Claude Code sessions can pick up project context without re-auditing the entire repo. This section should be updated at the end of every working session.
+
+## Acceptance Criteria
+
+- [ ] CLAUDE.md has a `## Current Phase` section appended at the end
+- [ ] Section includes: current sprint status, what's working, what's not built, known tech debt, blockers
+- [ ] Section has a `> Last updated:` timestamp
+- [ ] Habit documented: "Update this section at end of each session"
+
+## Technical Notes
+
+**File:** `CLAUDE.md` (project root)
+
+**Content to append:**
+
+```markdown
+## Current Phase
+
+> **Last updated:** 2026-03-01
+
+### Status: Cleanup Sprint → then Ramp-Up (Pre-Sprint 1)
+- **Setup phase (PF-001-PF-008):** COMPLETE
+- **Cleanup sprint (PF-027-PF-033):** IN PROGRESS - tech debt fixes before AI ramp-up
+- **Next up after cleanup:** PF-009 (Hello LLM - first Anthropic API call)
+- **Kanban:** `.kanban/BOARD.md` | `.kanban/board.html`
+
+### What's Working
+- Full upload-preview-submit pipeline (BCA CSV, NeoBank PDF, Default CSV)
+- 106 seeded category rules with longest-keyword-match
+- Dashboard with aggregated stats, top categories, 6-month cash flow
+- Docker Compose (PostgreSQL + .NET API + React frontend)
+
+### What's Not Built Yet
+- Python FastAPI AI service (no directory exists)
+- LLM integration (zero Anthropic/OpenAI usage)
+- Wise/Superbank/Bank Jago parsers
+- BankProfile entity, FX rate conversion, validation layer
+
+### Known Tech Debt (tracked in PF-027-PF-031)
+- Application.csproj references Infrastructure + Persistence (Clean Arch violation)
+- DTOs in wrong project (Infrastructure/Dtos/ but namespace says Application.Dtos)
+- N+1 queries in CategorizeAsync
+- ~100 lines of business logic in TransactionsController
+- Exception details leaked in HTTP 500 responses
+- TypeScript strict mode disabled
+- Zero ILogger usage
+
+### Blockers
+- None
+
+### Session Notes
+- 2026-03-01: Full repo audit completed. 7 cleanup tickets created (PF-027-PF-033). See docs/PROJECT_CONTEXT.md for original vision doc.
+```
+
+**Key habit:** At the end of each working session, update this section with what was done, what's next, and any blockers.
+
+## Dependencies
+
+- None
+
+## Notes
+
+_Estimated: 5 minutes. Context preservation — prevents losing session state between Claude Code conversations._


### PR DESCRIPTION
Repo audit identified tech debt from setup phase that should be addressed before starting AI ramp-up. Created kanban tickets for:
- PF-027: Delete scaffold leftovers (WeatherForecast, UnitTest1, CDN script)
- PF-028: Fix exception detail leaking in API responses
- PF-029: Fix N+1 query in CategorizeAsync
- PF-030: Move DTOs from Infrastructure to Application project
- PF-031: Extract dashboard aggregation from controller to service
- PF-032: Update PROJECT_CONTEXT.md to match actual codebase
- PF-033: Add Current Phase section to CLAUDE.md

Updated BOARD.md and board.html with cleanup sprint, filter button, and progress tracking (8/33 overall).